### PR TITLE
Rename GamePlayerController

### DIFF
--- a/lib/night_in_salem_web/channels/game_channel.ex
+++ b/lib/night_in_salem_web/channels/game_channel.ex
@@ -1,0 +1,3 @@
+defmodule NightInSalemWeb.GameChannel do
+  use NightInSalemWeb, :channel
+end

--- a/lib/night_in_salem_web/controllers/game_session_player_controller.ex
+++ b/lib/night_in_salem_web/controllers/game_session_player_controller.ex
@@ -1,4 +1,4 @@
-defmodule NightInSalemWeb.GamePlayerController do
+defmodule NightInSalemWeb.GameSessionPlayerController do
   use NightInSalemWeb, :controller
   alias NightInSalem.GameMasterSupervisor
   alias NightInSalem.GameMaster

--- a/lib/night_in_salem_web/router.ex
+++ b/lib/night_in_salem_web/router.ex
@@ -16,7 +16,7 @@ defmodule NightInSalemWeb.Router do
   scope "/", NightInSalemWeb do
     pipe_through :browser # Use the default browser stack
 
-    resources "/player", GamePlayerController, only: [:new, :create]
+    resources "/player", GameSessionPlayerController, only: [:new, :create]
     resources "/", GameSessionController
   end
 

--- a/lib/night_in_salem_web/templates/game_session/index.html.eex
+++ b/lib/night_in_salem_web/templates/game_session/index.html.eex
@@ -1,4 +1,4 @@
 <%= link("New Session", to: game_session_path(@conn, :new)) %>
 <br>
-<%= link("Join Session", to: game_player_path(@conn, :new)) %>
+<%= link("Join Session", to: game_session_player_path(@conn, :new)) %>
 <%#= link("Join Session", to: "/game_session/1/edit") %>

--- a/lib/night_in_salem_web/templates/game_session_player/new.html.eex
+++ b/lib/night_in_salem_web/templates/game_session_player/new.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @conn, game_player_path(@conn, :create), [as: :game_session, method: :post], fn f -> %>
+<%= form_for @conn, game_session_player_path(@conn, :create), [as: :game_session, method: :post], fn f -> %>
   <%= text_input f, :game_key, placeholder: "Game Key" %>
   <%= text_input f, :player_name, placeholder: "Player Name" %>
   <%= submit "Join Game" %>

--- a/lib/night_in_salem_web/views/game_player_view.ex
+++ b/lib/night_in_salem_web/views/game_player_view.ex
@@ -1,3 +1,0 @@
-defmodule NightInSalemWeb.GamePlayerView do
-  use NightInSalemWeb, :view
-end

--- a/lib/night_in_salem_web/views/game_session_player_view.ex
+++ b/lib/night_in_salem_web/views/game_session_player_view.ex
@@ -1,0 +1,3 @@
+defmodule NightInSalemWeb.GameSessionPlayerView do
+  use NightInSalemWeb, :view
+end


### PR DESCRIPTION
Rename GamePlayerController to GameSessionPlayerController.

We think this makes it a clearer that this controller is for defining logic at the interface of game sessions and players.